### PR TITLE
Initializing variables before they are passed to ADIOS2

### DIFF
--- a/Tutorial/brusselator/src/simulation/brusselator.f90
+++ b/Tutorial/brusselator/src/simulation/brusselator.f90
@@ -167,6 +167,7 @@ PROGRAM main
     CALL decomp_2d_fft_init
 
     CALL io_init (fname,decomp, nx, ny, nz, ierr)
+    name = fname
 
     ALLOCATE(Uhigh(decomp%xst(1):decomp%xen(1),&
         decomp%xst(2):decomp%xen(2),&

--- a/Tutorial/brusselator/src/simulation/savedata.f90
+++ b/Tutorial/brusselator/src/simulation/savedata.f90
@@ -83,6 +83,7 @@ MODULE BRUSSELATOR_IO
         real(kind=8), intent(in)    :: xcoords(:), ycoords(:), zcoords(:)
         integer                     :: ierr
 
+        ierr = 0
         call adios2_put (ad_engine, var_xcoords, xcoords, adios2_mode_sync, ierr)
         call adios2_put (ad_engine, var_ycoords, ycoords, adios2_mode_sync, ierr)
         call adios2_put (ad_engine, var_zcoords, zcoords, adios2_mode_sync, ierr)
@@ -180,6 +181,7 @@ MODULE BRUSSELATOR_IO
         END DO; END DO; END DO
 
 #ifdef ADIOS2
+        ierr = 0
         call mpi_comm_rank (mpi_comm_world, myrank, ierr)
         call adios2_begin_step (ad_engine, ierr)
         !if (myrank .eq. 0) call adios2_put (ad_engine, var_plotnum, plotnum, adios2_mode_sync, ierr)
@@ -241,6 +243,7 @@ MODULE BRUSSELATOR_IO
         integer, intent(out) :: ierr
 
 #ifdef ADIOS2
+        ierr = 0
         call adios2_close    (ad_engine, ierr)
         call adios2_finalize (adios2_handle, ierr)
 #endif


### PR DESCRIPTION
A few variables that valgrind complained about.  In particular, it wasn't clear what the difference was between "name" and "fname" in the main program function.  "name" is 64 characters long, and was never initialized.  "fname" holds the actual output file name, and is 100 characters long.  Using fname in the adios calls led to a compiler warning.  So I just copied fname to name, and it works fine.

Also, ierr needs to be initialized before making calls to ADIOS.