### PR TITLE
Remove override directive from ADIOS2_DIR

### DIFF
--- a/Tutorial/heat2d/cpp/make.settings
+++ b/Tutorial/heat2d/cpp/make.settings
@@ -13,7 +13,7 @@
 #
 # ADIOS v2 installation
 #
-override ADIOS2_DIR=/opt/adios2
+ADIOS2_DIR=/opt/adios2
 
 #
 # C++ settings

--- a/Tutorial/heat2d/fortran/make.settings
+++ b/Tutorial/heat2d/fortran/make.settings
@@ -4,7 +4,7 @@
 #
 
 ## Location of the ADIOS 2.x libraries
-override ADIOS2_DIR=/opt/adios2
+ADIOS2_DIR=/opt/adios2
 
 ## Location of the ADIOS 1.x libraries
 override ADIOS1_DIR=/opt/adios1


### PR DESCRIPTION
This allows it to now be also set from the make command line