### PR TITLE
Added use of adios2::Variable<T>::Span as option in gray-scott settings

### DIFF
--- a/Tutorial/gray-scott/simulation/gray-scott.cpp
+++ b/Tutorial/gray-scott/simulation/gray-scott.cpp
@@ -35,21 +35,27 @@ std::vector<double> GrayScott::u_noghost() const { return data_noghost(u); }
 
 std::vector<double> GrayScott::v_noghost() const { return data_noghost(v); }
 
+void GrayScott::u_noghost(double* u_no_ghost) const
+{
+	data_noghost(u, u_no_ghost);
+}
+
+void GrayScott::v_noghost(double* v_no_ghost) const
+{
+	data_noghost(v, v_no_ghost);
+}
+
 std::vector<double>
 GrayScott::data_noghost(const std::vector<double> &data) const
 {
     std::vector<double> buf(size_x * size_y * size_z);
-
-    for (int x = 1; x < size_x + 1; x++) {
-        for (int y = 1; y < size_y + 1; y++) {
-            for (int z = 1; z < size_z + 1; z++) {
-                buf[(x - 1) + (y - 1) * size_x + (z - 1) * size_x * size_y] =
-                    data[l2i(x, y, z)];
-            }
-        }
-    }
-
+    data_no_ghost_common(data, buf.data() );
     return buf;
+}
+
+void GrayScott::data_noghost(const std::vector<double>& data, double* data_no_ghost) const
+{
+    data_no_ghost_common(data, data_no_ghost);
 }
 
 void GrayScott::init_field()
@@ -227,4 +233,16 @@ void GrayScott::exchange(std::vector<double> &u, std::vector<double> &v) const
     exchange_xy(v);
     exchange_xz(v);
     exchange_yz(v);
+}
+
+void GrayScott::data_no_ghost_common(const std::vector<double>& data, double* data_no_ghost) const
+{
+	for (int x = 1; x < size_x + 1; x++) {
+	    for (int y = 1; y < size_y + 1; y++) {
+	        for (int z = 1; z < size_z + 1; z++) {
+	            data_no_ghost[(x - 1) + (y - 1) * size_x + (z - 1) * size_x * size_y] =
+	            data[l2i(x, y, z)];
+	        }
+	    }
+	}
 }

--- a/Tutorial/gray-scott/simulation/gray-scott.h
+++ b/Tutorial/gray-scott/simulation/gray-scott.h
@@ -28,6 +28,9 @@ public:
     std::vector<double> u_noghost() const;
     std::vector<double> v_noghost() const;
 
+    void u_noghost(double* u_no_ghost) const;
+    void v_noghost(double* v_no_ghost) const;
+
 protected:
     Settings settings;
 
@@ -75,6 +78,10 @@ protected:
     // Return a copy of data with ghosts removed
     std::vector<double> data_noghost(const std::vector<double> &data) const;
 
+    // pointer version
+    void data_noghost(const std::vector<double>& data, double* no_ghost) const;
+
+
     // Check if point is included in my subdomain
     inline bool is_inside(int x, int y, int z) const
     {
@@ -101,6 +108,11 @@ protected:
     {
         return z + y * (size_z + 2) + x * (size_y + 2) * (size_z + 2);
     }
+
+private:
+
+    void data_no_ghost_common(const std::vector<double>& data, double* data_no_ghost) const;
+
 };
 
 #endif

--- a/Tutorial/gray-scott/simulation/settings.cpp
+++ b/Tutorial/gray-scott/simulation/settings.cpp
@@ -15,7 +15,9 @@ void to_json(nlohmann::json &j, const Settings &s)
                        {"Dv", s.Dv},
                        {"noise", s.noise},
                        {"output", s.output},
-                       {"adios_config", s.adios_config}};
+                       {"adios_config", s.adios_config},
+                       {"adios_span", s.adios_span},
+					   {"mesh_type", s.mesh_type}};
 }
 
 void from_json(const nlohmann::json &j, Settings &s)
@@ -31,7 +33,9 @@ void from_json(const nlohmann::json &j, Settings &s)
     j.at("noise").get_to(s.noise);
     j.at("output").get_to(s.output);
     j.at("adios_config").get_to(s.adios_config);
+    j.at("adios_span").get_to(s.adios_span);
     j.at("mesh_type").get_to(s.mesh_type);
+
 }
 
 Settings::Settings()
@@ -47,6 +51,7 @@ Settings::Settings()
     noise = 0.0;
     output = "foo.bp";
     adios_config = "adios2.xml";
+    adios_span   = false;
     mesh_type = "image";
 }
 

--- a/Tutorial/gray-scott/simulation/settings.h
+++ b/Tutorial/gray-scott/simulation/settings.h
@@ -17,6 +17,7 @@ public:
     double noise;
     std::string output;
     std::string adios_config;
+    bool adios_span;
     std::string mesh_type;
 
     Settings();

--- a/Tutorial/gray-scott/simulation/settings.json
+++ b/Tutorial/gray-scott/simulation/settings.json
@@ -10,5 +10,6 @@
     "noise": 0.01,
     "output": "gs.bp",
     "adios_config": "adios2.xml",
+    "adios_span" : true,
     "mesh_type": "image"
 }


### PR DESCRIPTION
Illustrates how adios buffer memory can be used directly by the application as an option to reduce memory footprint. Tested on Titan.