### PR TITLE
StepMode::NextAvailable -> StepMode::Read

### DIFF
--- a/Tutorial/brusselator/src/analysis/norm_calc.cpp
+++ b/Tutorial/brusselator/src/analysis/norm_calc.cpp
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
     while(true) {
 
         // Begin step
-        adios2::StepStatus read_status = reader_engine.BeginStep(adios2::StepMode::NextAvailable, 10.0f);
+        adios2::StepStatus read_status = reader_engine.BeginStep(adios2::StepMode::Read, 10.0f);
         if (read_status == adios2::StepStatus::NotReady)
         {
             // std::cout << "Stream not ready yet. Waiting...\n";

--- a/Tutorial/brusselator/src/analysis/norm_calc2.cpp
+++ b/Tutorial/brusselator/src/analysis/norm_calc2.cpp
@@ -118,7 +118,7 @@ int main(int argc, char *argv[])
     while(true) {
 
         // Begin step
-        adios2::StepStatus read_status  = reader_engine.BeginStep (adios2::StepMode::NextAvailable, 0.0f);
+        adios2::StepStatus read_status  = reader_engine.BeginStep ();
         if (read_status != adios2::StepStatus::OK)
             break;
 

--- a/Tutorial/gray-scott/analysis/curvature.cpp
+++ b/Tutorial/gray-scott/analysis/curvature.cpp
@@ -115,8 +115,7 @@ int main(int argc, char *argv[])
     log << "step\tcompute_curvature" << std::endl;
 
     while (true) {
-        adios2::StepStatus status =
-            reader.BeginStep(adios2::StepMode::NextAvailable);
+        adios2::StepStatus status = reader.BeginStep();
 
         if (status != adios2::StepStatus::OK) {
             break;

--- a/Tutorial/gray-scott/analysis/find_blobs.cpp
+++ b/Tutorial/gray-scott/analysis/find_blobs.cpp
@@ -165,8 +165,7 @@ int main(int argc, char *argv[])
     log << "step\tcompute_blobs" << std::endl;
 
     while (true) {
-        adios2::StepStatus status =
-            reader.BeginStep(adios2::StepMode::NextAvailable);
+        adios2::StepStatus status = reader.BeginStep();
 
         if (status != adios2::StepStatus::OK) {
             break;

--- a/Tutorial/gray-scott/analysis/isosurface.cpp
+++ b/Tutorial/gray-scott/analysis/isosurface.cpp
@@ -238,8 +238,7 @@ int main(int argc, char *argv[])
     while (true) {
         auto start_step = std::chrono::steady_clock::now();
 
-        adios2::StepStatus status =
-            reader.BeginStep(adios2::StepMode::NextAvailable);
+        adios2::StepStatus status = reader.BeginStep();
 
         if (status != adios2::StepStatus::OK) {
             break;

--- a/Tutorial/gray-scott/analysis/pdf_calc.cpp
+++ b/Tutorial/gray-scott/analysis/pdf_calc.cpp
@@ -209,7 +209,7 @@ int main(int argc, char *argv[])
     while(true) {
 
         // Begin step
-        adios2::StepStatus read_status = reader.BeginStep(adios2::StepMode::NextAvailable, 10.0f);
+        adios2::StepStatus read_status = reader.BeginStep(adios2::StepMode::Read, 10.0f);
         if (read_status == adios2::StepStatus::NotReady)
         {
             // std::cout << "Stream not ready yet. Waiting...\n";

--- a/Tutorial/gray-scott/plot/render_isosurface.cpp
+++ b/Tutorial/gray-scott/plot/render_isosurface.cpp
@@ -83,8 +83,7 @@ void timer_func(vtkObject *object, unsigned long eid, void *clientdata,
     std::vector<double> normals;
     int step;
 
-    adios2::StepStatus status =
-        context->reader->BeginStep(adios2::StepMode::NextAvailable);
+    adios2::StepStatus status = context->reader->BeginStep();
 
     if (status != adios2::StepStatus::OK) {
         return;

--- a/Tutorial/heat2d/cpp/analysis/heatAnalysis.cpp
+++ b/Tutorial/heat2d/cpp/analysis/heatAnalysis.cpp
@@ -115,7 +115,7 @@ int main(int argc, char *argv[])
         while (true)
         {
             adios2::StepStatus status =
-                reader.BeginStep(adios2::StepMode::NextAvailable, 10.0f);
+                reader.BeginStep(adios2::StepMode::Read, 10.0f);
             if (status == adios2::StepStatus::NotReady)
             {
                 // std::cout << "Stream not ready yet. Waiting...\n";

--- a/Tutorial/heat2d/cpp/visualization/heatVisualization.cpp
+++ b/Tutorial/heat2d/cpp/visualization/heatVisualization.cpp
@@ -84,7 +84,7 @@ int main(int argc, char *argv[])
             while (true)
             {
                 adios2::StepStatus status =
-                    reader.BeginStep(adios2::StepMode::NextAvailable, 10.0f);
+                    reader.BeginStep(adios2::StepMode::Read, 10.0f);
                 if (status == adios2::StepStatus::NotReady)
                 {
                     // std::cout << "Stream not ready yet. Waiting...\n";

--- a/Tutorial/heat2d/fortran/simulation/io_adios2.F90
+++ b/Tutorial/heat2d/fortran/simulation/io_adios2.F90
@@ -84,7 +84,7 @@ subroutine io_write(tstep,curr)
 
     call MPI_BARRIER(app_comm, adios2_err)
 
-    call adios2_begin_step( bp_writer, adios2_step_mode_append, 0., &
+    call adios2_begin_step( bp_writer, adios2_step_mode_append, -1., &
                             istatus, adios2_err)
 
     ! We need the temporary array survive until EndStep, 


### PR DESCRIPTION
These are the changes required to the tutorial materials if the LastestAvailable PR (https://github.com/ornladios/ADIOS2/pull/1474) goes in. 
Notes:
 - Would have been fewer changes if default params had been utilized everywhere possible
 - BeginStep is a little weird now.
     * On the write side, you can specify a mode and timeout, but while the mode is used I don't know that we ever have a use for a writer side timeout.
     * On the reader side, there is only one applicable mode, so specification is useless, but you have to specify it in order to specify a timeout.  We should maybe fix this with overloading a BeginStep with only a timeout parameter.
 - One change here is changing the timeout from 0.0 to -1.  -1 is the default (blocking) as of a year or so ago.   0 means "poll", not blocking.  Doesn't matter for this use as it's a write, but we should probably use the right default as a matter of course.