### PR TITLE
Fix heat2d build error with latest ADIOS

### DIFF
--- a/Tutorial/heat2d/fortran/analysis/heatAnalysis_adios2_stream.F90
+++ b/Tutorial/heat2d/fortran/analysis/heatAnalysis_adios2_stream.F90
@@ -59,7 +59,7 @@ program reader
 
     ts = 0;
     do 
-        call adios2_begin_step(fh, adios2_step_mode_next_available, -1.0, istatus, ierr)
+        call adios2_begin_step(fh, istatus, ierr)
         if (ierr /= 0) then
             print '(" Failure when trying to get next step: ",a)', streamname
             exit


### PR DESCRIPTION
Removes the use of `adios2_step_mode_next_available`. Related to #31.

```
heatAnalysis_adios2_stream.F90:62:66:

         call adios2_begin_step(fh, adios2_step_mode_next_available, -1.0, istatus, ierr)
                                                                  1
Error: Symbol ‘adios2_step_mode_next_available’ at (1) has no IMPLICIT type
```