### PR TITLE
LockDefinitions() -> LockWriterDefinitions/LockReaderSelections()

### DIFF
--- a/Tutorial/heat2d/cpp/analysis/heatAnalysis.cpp
+++ b/Tutorial/heat2d/cpp/analysis/heatAnalysis.cpp
@@ -163,7 +163,7 @@ int main(int argc, char *argv[])
                 outIO.DefineAttribute<std::string>("description", 
                         "Temperature difference between two steps calculated in analysis", "dT");
 
-                outIO.LockDefinitions();
+                writer.LockWriterDefinitions();
 
                 MPI_Barrier(mpiReaderComm); // sync processes just for stdout
             }
@@ -174,7 +174,7 @@ int main(int argc, char *argv[])
 
             if (firstStep)
             {
-                inIO.LockDefinitions(); // a promise here that we don't change the read pattern over steps
+                reader.LockReaderSelections(); // a promise here that we don't change the read pattern over steps
             }
 
             // Arrays are read by scheduling one or more of them

--- a/Tutorial/heat2d/cpp/simulation/IO_adios2.cpp
+++ b/Tutorial/heat2d/cpp/simulation/IO_adios2.cpp
@@ -81,7 +81,7 @@ IO::IO(const Settings &s, MPI_Comm comm)
     // Some optimization:
     // we promise here that we don't change the variables over steps
     // (the list of variables, their dimensions, and their selections)
-    io.LockDefinitions();
+    writer.LockWriterDefinitions();
 }
 
 IO::~IO()

--- a/Tutorial/heat2d/cpp/visualization/heatVisualization.cpp
+++ b/Tutorial/heat2d/cpp/visualization/heatVisualization.cpp
@@ -126,7 +126,7 @@ int main(int argc, char *argv[])
 
                 if (firstStep)
                 {
-                    inIO.LockDefinitions(); // a promise here that we don't change the read pattern over steps
+                    reader.LockReaderSelections(); // a promise here that we don't change the read pattern over steps
                 }
 
                 reader.EndStep();


### PR DESCRIPTION
`IO::LockDefinitions()` was split into `Engine::LockWriterDefinitions()` and `Engine::LockReaderSelections()` (https://github.com/ornladios/ADIOS2/pull/1478).