### PR TITLE
Fix runtime error in render_isosurface

### DIFF
--- a/Tutorial/gray-scott/plot/render_isosurface.cpp
+++ b/Tutorial/gray-scott/plot/render_isosurface.cpp
@@ -10,6 +10,7 @@
 
 #include <adios2.h>
 
+#include <vtkAutoInit.h>
 #include <vtkActor.h>
 #include <vtkCallbackCommand.h>
 #include <vtkCellArray.h>
@@ -25,6 +26,8 @@
 #include <vtkRenderWindowInteractor.h>
 #include <vtkRenderer.h>
 #include <vtkSmartPointer.h>
+
+VTK_MODULE_INIT(vtkRenderingOpenGL2);
 
 typedef struct {
     vtkRenderView *renderView;


### PR DESCRIPTION
```text
Warning: In /Users/keichi/Projects/research/VTK-8.2.0/Rendering/Core/vtkPolyDataMapper.cxx, line 28
Error: no override found for 'vtkPolyDataMapper'.

Generic Warning: In /Users/keichi/Projects/research/VTK-8.2.0/Rendering/Core/vtkActor.cxx, line 43
Error: no override
```